### PR TITLE
Requirements - Always fetch latest of inicheck.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ coverage>=4.5.1
 coveralls>=1.3.0
 dateparser==0.7.2
 PyYAML==5.3
-inicheck==0.7.9
+inicheck
 setuptools_scm==3.5.0


### PR DESCRIPTION
Remove the version restriction for inicheck.